### PR TITLE
fix(deps): declare pydeflate, numpy and python-dateutil as direct dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,9 +21,12 @@ classifiers = [
 
 dependencies = [
     "bblocks>=1.4.3,<2",
+    "numpy>=2.3.3",
     "oda-data>=2.3.1",
     "openpyxl>=3.1.5",
     "pandas>=2.3.2",
+    "pydeflate>=2.3.3",
+    "python-dateutil>=2.9.0.post0",
     "requests>=2.32.5",
     "selenium>=4.35.0",
     "thefuzz[speedup]>=0.22.1",

--- a/uv.lock
+++ b/uv.lock
@@ -338,9 +338,12 @@ version = "1.2.2"
 source = { editable = "." }
 dependencies = [
     { name = "bblocks" },
+    { name = "numpy" },
     { name = "oda-data" },
     { name = "openpyxl" },
     { name = "pandas" },
+    { name = "pydeflate" },
+    { name = "python-dateutil" },
     { name = "requests" },
     { name = "selenium" },
     { name = "thefuzz" },
@@ -357,9 +360,12 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "bblocks", specifier = ">=1.4.3,<2" },
+    { name = "numpy", specifier = ">=2.3.3" },
     { name = "oda-data", specifier = ">=2.3.1" },
     { name = "openpyxl", specifier = ">=3.1.5" },
     { name = "pandas", specifier = ">=2.3.2" },
+    { name = "pydeflate", specifier = ">=2.3.3" },
+    { name = "python-dateutil", specifier = ">=2.9.0.post0" },
     { name = "requests", specifier = ">=2.32.5" },
     { name = "selenium", specifier = ">=4.35.0" },
     { name = "thefuzz", extras = ["speedup"], specifier = ">=0.22.1" },


### PR DESCRIPTION
Addresses the `climate-finance` half of ONEcampaign/bblocks#205.

`climate_finance` imports `pydeflate`, `numpy` and `dateutil` directly but declared none of them. `pydeflate` arrived through `oda-data`, the other two through `pandas`. The module-level `from pydeflate import ...` in `core/deflators.py` is reached at package import time by way of `core/data.py`, so `import climate_finance` needs `pydeflate` unconditionally, and the day `oda-data` drops or renames it the package breaks on import with nothing in its own metadata to explain why. `numpy` is imported across six modules and `dateutil` in `oecd/crdf/tools.py`, both riding on `pandas` in the same way.

All three floors are read out of the existing `uv.lock` rather than chosen, so this resolves to exactly the versions it resolved to before. `pydeflate>=2.3.3` also matches what `oda-data` itself declares. None of the three takes an upper cap: `pydeflate` 2.6.0 and later require Python 3.12, so this package's own `requires-python` floor of 3.11 already keeps 3.11 users on 2.5.0 and below without help.

`requests` is left alone. It is declared with no direct import anywhere in `src/`, but removing a declared dependency is a different and riskier change than adding one, and it belongs in its own cleanup.

The issue's wording asks that installing this without `oda-data` present still imports, and that is not achievable here: `oda-data` is a hard, non-optional dependency and roughly ten modules import it at module level, so `import climate_finance` reaches `oda_data` no matter what this file says. What is achievable, and what this proves, is provenance — `pydeflate` is now installed because `climate-finance` asked for it rather than because `oda-data` happened to bring it.

`core/deflators.py` is untouched. Its current-prices path is separately broken, and that is tracked in ONEcampaign/bblocks#219.

Testing: `uv lock --check` and `uv build` pass, and the built wheel's metadata carries all three `Requires-Dist` entries. In a clean Python 3.12 venv holding every declared dependency except `oda-data`, `import pydeflate` succeeds with `oda_data` absent. `uv run pytest tests/ -v` gives 53 passed, 3 failed, 1 skipped, identical to the same run on `main`; the three failures are pre-existing and hit OECD's live CRS bulk download.
