### PR TITLE
chore(release): 1.2.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changes to the climate_finance package
 
+## 1.2.3 (2026-08-11)
+- Declares `pydeflate`, `numpy` and `python-dateutil` as direct dependencies instead of relying on them arriving transitively.
+
 ## 1.2.2 (2025-12-15)
 - Fixes indicator compatibility issue with oda-data >= 2.3.1 by switching to the new `core_multilateral_contributions_by_provider` function.
 - Updates `oda-data` dependency to >= 2.3.1.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "climate-finance"
-version = "1.2.2"
+version = "1.2.3"
 description = "Climate Finance data"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/src/climate_finance/__init__.py
+++ b/src/climate_finance/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "1.2.2"
+__version__ = "1.2.3"
 
 # Easy access to importers
 

--- a/uv.lock
+++ b/uv.lock
@@ -334,7 +334,7 @@ wheels = [
 
 [[package]]
 name = "climate-finance"
-version = "1.2.2"
+version = "1.2.3"
 source = { editable = "." }
 dependencies = [
     { name = "bblocks" },


### PR DESCRIPTION
This releases the direct-dependency declarations merged in #89, bumping the package to 1.2.3 so the fix reaches PyPI. `pydeflate` was previously reaching users only through `oda-data`, along with `numpy` and `python-dateutil` arriving transitively; all three are now declared directly in `pyproject.toml`. The version string is updated in `pyproject.toml` and `src/climate_finance/__init__.py`, `uv.lock` is regenerated, and `CHANGELOG.md` gets a new entry. No behavior changes.

Testing: `uv lock --check` (failed before regenerating, passes after), `uv build` producing `climate_finance-1.2.3-py3-none-any.whl`, wheel METADATA inspection confirming version 1.2.3 and the three `Requires-Dist` entries, and `uv run pytest tests/ -v` under Python 3.12 (53 passed, 3 failed on live OECD network calls, 1 skipped, matching the pre-existing baseline).