### PR TITLE
ci: publish to PyPI via OIDC trusted publishing

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -3,7 +3,7 @@ name: release & publish
 on:
   push:
     tags:
-      - 'v*'
+      - "v*"
   workflow_dispatch:
 
 jobs:
@@ -15,8 +15,14 @@ jobs:
       matrix:
         python-versions: ["3.10"]
 
+    # Matches the environment named in the PyPI trusted publisher for this
+    # project. The names must agree or PyPI rejects the OIDC claim.
+    environment: pypi
     permissions:
-      contents: write  # needed by action-gh-release
+      # Declaring any permission drops the rest to none, so checkout needs
+      # contents spelled out alongside the OIDC token the publish step mints.
+      contents: read
+      id-token: write
 
     steps:
       - name: Checkout
@@ -38,7 +44,9 @@ jobs:
       - name: Show dist/
         run: ls -l dist
 
-      - name: Publish to PyPI (uv)
-        env:
-          UV_PUBLISH_TOKEN: ${{ secrets.PYPI_API_TOKEN }}
-        run: uv publish
+      - name: Publish package to PyPI
+        uses: pypa/gh-action-pypi-publish@dc37677b2e1c63e2034f94d8a5b11f265b73ba33 # v1.14.2
+        with:
+          skip-existing: true
+          verify-metadata: true
+          verbose: true


### PR DESCRIPTION
Part of ONEcampaign/bblocks#206

This moves the PyPI release step from a stored API token to GitHub OIDC trusted publishing, following the same pattern already in place for imf-reader. The publish step now uses the pinned pypa/gh-action-pypi-publish action under a pypi deployment environment, minting a short-lived OIDC token instead of reading UV_PUBLISH_TOKEN from a long-lived secret. The permissions block is spelled out as contents: read plus id-token: write, since declaring any permission drops the rest to none and the publish step needs the OIDC token that grant mints. The environment name has to match the trusted publisher configured on PyPI or the OIDC claim gets rejected.

While in the file, the contents: write grant is replaced with contents: read. It carried a comment saying it was needed by action-gh-release, but no such step exists in this workflow, so the broader write permission was unused and is now corrected to match what the job actually does.

Everything else is untouched: the push tag trigger and workflow_dispatch trigger, uv build --no-sources including the no-sources flag, and the Python version pinned at 3.10. The single-entry python-versions matrix is left as is rather than collapsed, since removing it would touch more of the file than this change needs.

The PYPI_API_TOKEN secret is deliberately left in the repo for now. It is no longer read by this workflow, but it stays available as a fallback until the first OIDC release actually publishes successfully. Before the next tag is pushed, the PyPI project needs a trusted publisher registered for this repo, workflow file, and pypi environment name, matching what was just set up on the GitHub side; without that registration the OIDC publish will fail closed.

Testing: validated the workflow YAML with PyYAML's safe_load, confirmed the pinned pypa/gh-action-pypi-publish SHA resolves to tag v1.14.2 via the GitHub API, and confirmed the pypi environment now exists on this repo with the required-reviewer and v* tag deployment branch policy matching the imf-reader reference. Did not run an actual release, since that requires the PyPI trusted publisher to be registered first.
