### PR TITLE
ci: add a test workflow so PRs have a status check

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,37 @@
+name: tests
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+  workflow_dispatch:
+
+jobs:
+  test:
+    name: test
+    runs-on: ubuntu-latest
+
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ["3.11", "3.12", "3.13"]
+
+    steps:
+      - name: Check-out repository
+        uses: actions/checkout@v7
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v10.0.0
+
+      - name: Set up Python ${{ matrix.python-version }}
+        run: uv python install ${{ matrix.python-version }}
+
+      - name: Install the project
+        run: uv sync --frozen --python ${{ matrix.python-version }}
+
+      # Tests marked `integration` download OECD bulk data over the network, so
+      # they fail whenever the upstream endpoint is slow or unavailable. They
+      # are deselected here to keep this a deterministic gate; run them locally
+      # with `uv run pytest -m integration`.
+      - name: Run tests
+        run: uv run --frozen --python ${{ matrix.python-version }} pytest -m "not integration"

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -26,12 +26,16 @@ jobs:
       - name: Set up Python ${{ matrix.python-version }}
         run: uv python install ${{ matrix.python-version }}
 
+      # --locked, not --frozen: --frozen would install the existing lockfile
+      # without checking it still matches pyproject.toml, so a PR that edits a
+      # dependency and forgets to relock would pass this gate while testing a
+      # dependency set no user will resolve. --locked fails on that drift.
       - name: Install the project
-        run: uv sync --frozen --python ${{ matrix.python-version }}
+        run: uv sync --locked --python ${{ matrix.python-version }}
 
       # Tests marked `integration` download OECD bulk data over the network, so
       # they fail whenever the upstream endpoint is slow or unavailable. They
       # are deselected here to keep this a deterministic gate; run them locally
       # with `uv run pytest -m integration`.
       - name: Run tests
-        run: uv run --frozen --python ${{ matrix.python-version }} pytest -m "not integration"
+        run: uv run --no-sync --python ${{ matrix.python-version }} pytest -m "not integration"


### PR DESCRIPTION
Part of ONEcampaign/bblocks#206

This repo had no CI. Its only workflow was `release.yaml`, so nothing ran on a pull request and the last three merged PRs have zero check runs on their head commits. That blocks the second half of #206's first criterion, which asks that every repo with a release workflow protect its default branch "requiring a pull request and passing status checks". Branch protection went on `main` today with zero required approvals and conversation resolution enabled, but with no CI there was nothing to require passing, so the protection is a pull request gate and no more.

`tests.yml` runs the suite on ubuntu across Python 3.11, 3.12 and 3.13, matching `requires-python = ">=3.11"` and the versions in the trove classifiers. It installs with `uv sync --locked`, which fails the job when `uv.lock` has drifted from `pyproject.toml`. `--frozen` would install the existing lockfile without checking it, so a PR that edits a dependency and forgets to relock would pass this gate while testing a dependency set no user will resolve. `fail-fast` is off so one bad interpreter does not hide the state of the others.

Tests marked `integration` are deselected. Three of them, `test_climate_data_loads_spending_with_oecd_methodology`, `test_one_methodology_produces_lower_totals_than_oecd` and `test_france_2020_output_snapshot`, drive `ClimateData` through a live OECD CRS bulk download and fail with "Maximum retries (5) exceeded" whenever that endpoint is slow or down. A required check that depends on a third party's uptime is worse than no check, since it trains people to merge past red. They still run locally with `uv run pytest -m integration`.

One thing deliberately left alone. `release.yaml` builds on Python 3.10, which is below the `>=3.11` floor this package declares. It works today only because that workflow builds without installing the project, so nothing resolves the requirement. Worth fixing, but it is a release concern rather than a testing one and does not belong in this diff.

Merging this produces three new check contexts, `test (3.11)`, `test (3.12)` and `test (3.13)`. They have to be added to the branch protection by hand afterwards, or the gate stays advisory.

Testing: the suite was run locally on 3.11, 3.12 and 3.13, giving 53 passed and 4 deselected on each. Without the marker filter the same suite gives 3 failed and 53 passed, the three failures being the network-dependent tests named above. The drift check was verified rather than assumed: adding a dependency to `pyproject.toml` without relocking makes `uv sync --locked` fail with "The lockfile at `uv.lock` needs to be updated", while `uv sync --frozen` installs it without complaint. The YAML parses, and both action refs were confirmed to resolve.
